### PR TITLE
gtcars missing variable description (msrp)

### DIFF
--- a/R/datasets.R
+++ b/R/datasets.R
@@ -116,6 +116,7 @@
 #'   both types (`am`), or, direct drive (`dd`)}
 #'   \item{ctry_origin}{The country name for where the vehicle manufacturer
 #'   is headquartered}
+#'   \item{msrp}{Manufacturer's suggested retail price in U.S. dollars (USD)}
 #' }
 #'
 #' @examples


### PR DESCRIPTION
# Summary

PR adds an entry for `msrp` as "Manufacturer's suggested retail price in U.S. dollars (USD)" in the dataset documentation (datasets.R file) for `gt::gtcars`. Documentation should update on build.

gtcars is great for teaching and the msrp column lacks a variable description.

# Related GitHub Issues and PRs

none

# Checklist

- [ x ] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
- [ x ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ x ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
